### PR TITLE
Add two missing .C 

### DIFF
--- a/src/datamaestro_text/datasets/irds/datasets.py
+++ b/src/datamaestro_text/datasets/irds/datasets.py
@@ -103,7 +103,7 @@ class TrainingTripletsDataset(Dataset):
     SUFFIX = "docpairs"
 
     def _prepare(self, download=False) -> Documents:
-        return TrainingTriplets(
+        return TrainingTriplets.C(
             id=self.fullid,
         )
 

--- a/src/datamaestro_text/transforms/ir/__init__.py
+++ b/src/datamaestro_text/transforms/ir/__init__.py
@@ -150,7 +150,7 @@ class ShuffledTrainingTripletsLines(Task):
 
     def task_outputs(self, dep):
         return dep(
-            ir.TrainingTripletsLines(
+            ir.TrainingTripletsLines.C(
                 id="",
                 path=self.path,
                 topic_ids=self.topic_ids,


### PR DESCRIPTION
While working on updating the cross-encoders experiment, I encountered some errors related to missing .C in datamaestro_text.